### PR TITLE
Fix bug with database in Helm and improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,23 @@ It is important to note that at build time the image building process needs the 
 The project also comes with a [docker-compose.yml](docker-compose.yaml) file so a development environment can be quicked off very quickly. As reference, the image building argument for this environming will be set to `testing`.
 
 ## 4. Helm related work
-To quickly deploy the application on top of a k8s cluster, a helm chart has been developed. It can be found [HERE](helm/stakefish-chart/).  
-Before using it, some k8s secrets need to be put in place. Please refer to the example [secrets.yaml](helm/stakefish-chart/example/secrets.yaml).  
-This chart uses also as dependency the postgres chart created by [Bitnami](https://bitnami.com/stack/postgresql/helm).
+To quickly deploy the application on top of a `k8s` cluster, a `Helm` chart has been developed. To install the application using `Helm`, please add the right `Helm` reposotory and install it from there.  
+**⚠️Before using it⚠️**, some `k8s` secrets need to be put in place. Please refer to the example [secrets.yaml](helm/stakefish-chart/example/secrets.yaml). If these secrets are not set before installing the chart, the pods won't come up. This behaviour could be improved in the future by auto-generating secrets if they are not present.  
+This chart uses also as dependency the postgres chart created by [Bitnami](https://bitnami.com/stack/postgresql/helm).  
+To install the chart, follow the steps below:
+Add my `Helm` repo to your `Helm` installation:
+```
+$ helm repo add stakefish https://mikeletux.github.io/helm-chart/
+```
+Update your `Helm` repos:
+```
+$ helm repo update
+```
+Proceed to install the chart:
+```
+$ helm search repo stakefish
+$ helm install stakefish stakefish/stakefish-chart
+```
 
 ## 5. GitHub Actions related work
 This project implements a CI pipeline built upon `GitHub Actions`. The pipeline is triggered every single time some code is pused to any branch, no matter which one. The only different behavior occurs when in a pull request. In this event, neither the `Docker` container built is pushed to github container registry nor the `Helm` chart is published.  

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,9 @@ services:
     restart: always
     container_name: stakefish-db
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: stakefish-user
+      POSTGRES_PASSWORD: stakefish-password
+      POSTGRES_DB: stakefish
     ports:
       - '5432:5432'
     volumes: 
@@ -25,9 +26,9 @@ services:
       - '3000:3000'
     environment:
       FISH_PG_HOST: stakefish-db:5432
-      FISH_PG_USER: postgres
-      FISH_PG_PASS: postgres
-      FISH_PG_DATABASE: postgres
+      FISH_PG_USER: stakefish-user
+      FISH_PG_PASS: stakefish-password
+      FISH_PG_DATABASE: stakefish
       FISH_PG_API_ADDR: 0.0.0.0:3000
     links:
       - stakefish-db

--- a/helm/stakefish-chart/example/secrets.yaml
+++ b/helm/stakefish-chart/example/secrets.yaml
@@ -4,5 +4,5 @@ metadata:
   name: stakefish-api-secret
 type: Opaque
 stringData:
-  postgres-password: "postgres"
-  fish-pg-user: "postgres"
+  postgres-password: "postgres-password"
+  password: "stakefish-password"

--- a/helm/stakefish-chart/templates/deployment.yaml
+++ b/helm/stakefish-chart/templates/deployment.yaml
@@ -26,20 +26,17 @@ spec:
           - containerPort: {{ .Values.containerPort }}
         env:
         - name: FISH_PG_HOST
-          value: "{{ .Release.Name}}-postgresql:{{ .Values.postgresql.global.postgresql.service.ports.postgresql }}"
+          value: "{{ .Release.Name}}-postgresql:{{ .Values.global.postgresql.service.ports.postgresql }}"
         - name: FISH_PG_API_ADDR
           value: "0.0.0.0:{{ .Values.loadBalancerPort }}"
         - name: FISH_PG_DATABASE
-          value: {{ .Values.postgresql.global.postgresql.auth.database }}
+          value: {{ .Values.global.postgresql.auth.database }}
         - name: FISH_PG_USER
-          valueFrom:
-            secretKeyRef:
-              name: stakefish-api-secret
-              key: fish-pg-user
+          value: {{ .Values.global.postgresql.auth.username }}
         - name: FISH_PG_PASS
           valueFrom:
             secretKeyRef:
               name: stakefish-api-secret
-              key: postgres-password
+              key: password
         
 status: {}

--- a/helm/stakefish-chart/values.yaml
+++ b/helm/stakefish-chart/values.yaml
@@ -16,13 +16,6 @@ loadBalancerPort: 3000
 postgresql:
   auth:
     existingSecret: stakefish-api-secret
-  global:
-    postgresql:
-      auth:
-        database: "postgres"
-      service:
-        ports:
-          postgresql: "5432"
   primary:
     initdb:
       scripts:
@@ -40,3 +33,12 @@ postgresql:
             FOREIGN KEY (query_id)
             REFERENCES query (id)
             );
+
+global:
+  postgresql:
+    auth:
+      username: "stakefish-user"
+      database: "stakefish"
+    service:
+      ports:
+        postgresql: "5432"

--- a/pkg/infra/db.go
+++ b/pkg/infra/db.go
@@ -57,7 +57,7 @@ func (p *PostgresConnector) SaveQuery(query models.Query) error {
 
 // RetrieveLastTwentyQueries returns the last 20 queries stored in the database in a descendent manner.
 func (p *PostgresConnector) RetrieveLastTwentyQueries() ([]models.Query, error) {
-	var queries []models.Query
+	queries := make([]models.Query, 0, 20)
 	err := p.db.Model(&queries).
 		Relation("Addresses").
 		Order("created_at DESC").


### PR DESCRIPTION
This PR comes with the following bug fixes and improvements:
## Bug fixes
 - The global vars in helm chart were not set correctly so the chart was creating the postgres pod without the correct configuration, leading to connectivity issues between API and database.  
This has been solved setting the global vars accordingly. Also a custom db and user has been added instead using the default ones.
- The endpoint `/v1/history` was returning `null` if there was no items in the database. This behavior has been changed to return an empty list (`[]`) instead `null`.

## Improvements
 - Readme.md was improved with additional information about `Helm` and added steps to install the chart from `https://mikeletux.github.io/helm-chart/` `Helm` repository.
 - `Docker-compose` file uses now custom user and db for its operation.

## Changes
- In the `Helm` chart, a custom user `stakefish-user` and custom database `stakefish` are being used instead of the default ones as before. This user and database tuple will be used in the database Pod as well as in the API deployment (global vars).  
- The example secrets.yaml file (`helm/stakefish-chart/example/secrets.yaml`) has been updated with the new values. Now there are two secrets. `postgres-password` is the default `postgres` user password and `password` which is the password for the user `stakefish-user` that will be used by the API to query the database. 